### PR TITLE
Add missing react-redux dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.55.0",
     "react-router-dom": "6.0.2",
+    "react-redux": "^9.1.2",
     "react-router-hash-link": "^2.4.3",
     "recharts": "^2.15.2",
     "redux": "^5.0.1",


### PR DESCRIPTION
The Vercel build was failing with the error: `[vite]: Rollup failed to resolve import "react-redux" from "/vercel/path0/src/index.jsx".`

This was caused by the `react-redux` package being used in the code but not being listed as a dependency in `package.json`.

This commit adds `react-redux` to the dependencies to resolve the build error.

---
این کامیت وابستگی `react-redux` را که در پروژه استفاده شده ولی در `package.json` ثبت نشده بود، اضافه می‌کند تا مشکل بیلد در Vercel حل شود.